### PR TITLE
Fix an issue with certain findings

### DIFF
--- a/DefectDojoPlugin.py
+++ b/DefectDojoPlugin.py
@@ -429,6 +429,18 @@ class BurpExtender(IBurpExtender, ITab):
                     ureqresp.append({"req": self._helpers.bytesToString(
                         mess.getRequest()), "resp": self._helpers.bytesToString(mess.getResponse())})
                 url = str(self._issList[issues[i]].getUrl())
+            try :
+                json.loads(description)
+            except:
+                description=json.dumps(description)
+            try :
+                json.loads(impact)
+            except:
+                impact=json.dumps(impact)
+            try :
+                json.loads(mitigation)
+            except:
+                mitigation=json.dumps(mitigation)
             data = {
                 'title': title,
                 'description': description,


### PR DESCRIPTION
Certain findings will contain `\'` sequences which will not handle nicely when sent over as part of a `json.dumps(dictionary)` as the values will cause errors when the server `json.loads()` them . In consequence this will make some issues look even uglier but now they're sendable ?